### PR TITLE
repro

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import jQuery from 'jquery';
 type JQueryStaticOriginal = JQueryStatic;
 import terminal from 'jquery.terminal';
-
+import type { JQueryTerminal, JQueryStatic } from 'jquery.terminal';
 
 function foo(jQuery: JQueryStaticOriginal) {
     return jQuery;


### PR DESCRIPTION
Sorry, I forget about this important part. I had this code:

```typescript

import jQuery from 'jquery';

type JQueryStaticOriginal = JQueryStatic;

import terminal from 'jquery.terminal';
import type { JQueryTerminal, JQueryStatic } from 'jquery.terminal';


function foo(jQuery: JQueryStaticOriginal) {
    return jQuery;
}

foo(jQuery);

terminal(window, jQuery);

```

And only copied the foo thing without testing it.